### PR TITLE
Support RGBW lights

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,10 +62,10 @@
     "node-fetch": "^2.6.0"
   },
   "devDependencies": {
-    "@types/chai": "^4.2.7",
+    "@types/chai": "^4.2.8",
     "@types/dnssd": "^0.4.1",
     "@types/mocha": "^5.2.7",
-    "@types/node": "^13.1.0",
+    "@types/node": "^13.5.2",
     "@types/node-fetch": "^2.5.4",
     "chai": "^4.2.0",
     "mocha": "^6.2.2",

--- a/src/power-plug.ts
+++ b/src/power-plug.ts
@@ -18,7 +18,7 @@ class OnOffProperty extends Property {
             '@type': 'OnOffProperty',
             type: 'boolean',
             title: 'On',
-            description: 'Wether the device is on or off'
+            description: 'Whether the device is on or off'
         });
     }
 

--- a/src/tasmota-adapter.ts
+++ b/src/tasmota-adapter.ts
@@ -70,7 +70,7 @@ export class TasmotaAdapter extends Adapter {
       const body = await result.text();
 
       if (body.indexOf('Tasmota') >= 0) {
-        console.log(`Discovered Tasmota at ${name}`);
+        console.log(`Discovered Tasmota thingamagig at ${name}`);
         let device = this.devices[name];
 
         if (!device) {
@@ -80,12 +80,20 @@ export class TasmotaAdapter extends Adapter {
           this.handleDeviceAdded(device);
           device.startPolling(Math.max(pollInterval || 1000, 500));
 
-          const response = await getStatus(host, password, 'Color');
-          const result = await response.json();
+          console.log(`Querying properties of ${name}`);
+          const colorResponse = await getStatus(host, password, 'Color');
+          const colorResult = await colorResponse.json();
+          const color = colorResult.Color ? colorResult : "";
+          console.log(`${name}-color=${color}`);
 
-          if (result.Color && result.Color.length == 6) {
-            console.log('Found color device');
-            const colorDevice = new Light(this, `${name}-color`, host, password, result.Color);
+          const dimmerResponse = await getStatus(host, password, 'Dimmer');
+          const dimmerResult = await dimmerResponse.json();
+          const dimmer = dimmerResult.Dimmer ? dimmerResult : 0;
+          console.log(`${name}-dimmer=${dimmer}`);
+
+          if (color.length == 6 || color.length == 8 || dimmer != 0) {
+            console.log('Found light device');
+            const colorDevice = new Light(this, `${name}-light`, host, password, color, dimmer);
             this.handleDeviceAdded(colorDevice);
             colorDevice.startPolling(Math.max(pollInterval || 1000, 500));
           }

--- a/src/tasmota-adapter.ts
+++ b/src/tasmota-adapter.ts
@@ -70,7 +70,7 @@ export class TasmotaAdapter extends Adapter {
       const body = await result.text();
 
       if (body.indexOf('Tasmota') >= 0) {
-        console.log(`Discovered Tasmota thingamagig at ${name}`);
+        console.log(`Discovered Tasmota at ${name}`);
         let device = this.devices[name];
 
         if (!device) {
@@ -80,20 +80,17 @@ export class TasmotaAdapter extends Adapter {
           this.handleDeviceAdded(device);
           device.startPolling(Math.max(pollInterval || 1000, 500));
 
-          console.log(`Querying properties of ${name}`);
           const colorResponse = await getStatus(host, password, 'Color');
           const colorResult = await colorResponse.json();
           const color = colorResult.Color ? colorResult : "";
-          console.log(`${name}-color=${color}`);
 
           const dimmerResponse = await getStatus(host, password, 'Dimmer');
           const dimmerResult = await dimmerResponse.json();
           const dimmer = dimmerResult.Dimmer ? dimmerResult : 0;
-          console.log(`${name}-dimmer=${dimmer}`);
 
           if (color.length == 6 || color.length == 8 || dimmer != 0) {
-            console.log('Found light device');
-            const colorDevice = new Light(this, `${name}-light`, host, password, color, dimmer);
+            console.log('Found color device');
+            const colorDevice = new Light(this, `${name}-color`, host, password, color, dimmer);
             this.handleDeviceAdded(colorDevice);
             colorDevice.startPolling(Math.max(pollInterval || 1000, 500));
           }


### PR DESCRIPTION
The minimum for reasonable behavior for #11 is to check for a color length of 8, and to trim the color back down to 6 so the WebThings UI shows the color selected.

Adding support for a brightness property is just to be nice.

Changing the OnOffProperty to query the tasmota Power property allows the color selected in WebThings to be persisted.

I'm happy to split those out into separate requests or adjust coding style if there's any changes you would like.