### PR TITLE
Support for CT lights

### DIFF
--- a/src/light.ts
+++ b/src/light.ts
@@ -147,7 +147,9 @@ class ColorTemperatureProperty extends WritableProperty<number> {
             '@type': 'ColorTemperatureProperty',
             type: 'integer',
             title: 'Color Temperature',
-            description: 'The color temperature of the light'
+            description: 'The color temperature of the light',
+            minimum: 2700,
+            maximum: 6500
         },
             async value => {
                 // Convert from Kelvin to the Tasmota range of 153 - 500 before setting value

--- a/src/light.ts
+++ b/src/light.ts
@@ -150,9 +150,10 @@ class ColorTemperatureProperty extends WritableProperty<number> {
             description: 'The color temperature of the light'
         },
             async value => {
-                var ctTasmota = Math.round((value-1025)/10.95);
+                // Convert from Kelvin to the Tasmota range of 153 - 500 before setting value
+                var ctKelvin = Math.max(2700,Math.min(6500,value));
+                var ctTasmota = Math.round((ctKelvin-1025)/10.95);
                 ctTasmota = 500-ctTasmota+153;
-                console.log(`CT Kelvin: ${value}, Tasmota: ${ctTasmota}`);
                 const result = await setStatus(host, password, 'CT', <string><unknown>ctTasmota);
 
                 if (result.status != 200) {
@@ -176,9 +177,9 @@ class ColorTemperatureProperty extends WritableProperty<number> {
                 const result = await response.json();
                 if(result)
                 {
+                  // Convert from the Tasmota range of 153 - 500 to Kelvin before updating value
                   const ctTasmota: number = ((500-result?.CT) || 0)+153;
                   const ctKelvin: number = Math.round(10.95*ctTasmota+1025);
-                  //console.log(`CT Tasmota: ${ctTasmota}, Kelvin: ${ctKelvin}`);
                   this.update(ctKelvin);
                 }
             });

--- a/src/light.ts
+++ b/src/light.ts
@@ -150,7 +150,8 @@ class ColorTemperatureProperty extends WritableProperty<number> {
             description: 'The color temperature of the light'
         },
             async value => {
-                var ctTasmota = 500-(value-1025)/10.95+153;
+                var ctTasmota = Math.round((value-1025)/10.95);
+                ctTasmota = 500-ctTasmota+153;
                 console.log(`CT Kelvin: ${value}, Tasmota: ${ctTasmota}`);
                 const result = await setStatus(host, password, 'CT', <string><unknown>ctTasmota);
 
@@ -176,9 +177,9 @@ class ColorTemperatureProperty extends WritableProperty<number> {
                 if(result)
                 {
                   const ctTasmota: number = ((500-result?.CT) || 0)+153;
-                  const ctKelvin: number = 10.95*ctTasmota+1025;
-                  console.log(`CT Tasmota: ${ctTasmota}, Kelvin: ${ctKelvin}`);
-                  this.update(result.CT);
+                  const ctKelvin: number = Math.round(10.95*ctTasmota+1025);
+                  //console.log(`CT Tasmota: ${ctTasmota}, Kelvin: ${ctKelvin}`);
+                  this.update(ctKelvin);
                 }
             });
     }

--- a/src/light.ts
+++ b/src/light.ts
@@ -180,7 +180,7 @@ export class Light extends Device {
 
         const colorTemperatureProperty = new ColorTemperatureProperty(this,
             async value => {
-                var ctTasmota = (value-102500)/1095;
+                var ctTasmota = (value-102.500)/10.95;
                 if(value != 0)
                 {
                     console.log(`CT Kelvin: ${value}, Tasmota: ${ctTasmota}`);
@@ -208,7 +208,7 @@ export class Light extends Device {
                 const response = await getStatus(this.host, this.password, 'CT');
                 const result = await response.json();
                 const ctTasmota: number = result?.CT || 0;
-                const ctKelvin: number = 1095*ctTasmota+102500;
+                const ctKelvin: number = 10.95*ctTasmota+102.500;
                 if(ctTasmota != 0)
                 {
                     console.log(`CT Tasmota: ${ctTasmota}, Kelvin: ${ctKelvin}`);

--- a/src/light.ts
+++ b/src/light.ts
@@ -146,11 +146,13 @@ class ColorTemperatureProperty extends WritableProperty<number> {
         super(device, 'colorTemperature', {
             '@type': 'ColorTemperatureProperty',
             type: 'integer',
-            title: 'ColorTemperature',
+            title: 'Color Temperature',
             description: 'The color temperature of the light'
         },
             async value => {
-                const result = await setStatus(host, password, 'CT', <string><unknown>value);
+                var ctTasmota = 500-(value-1025)/10.95+153;
+                console.log(`CT Kelvin: ${value}, Tasmota: ${ctTasmota}`);
+                const result = await setStatus(host, password, 'CT', <string><unknown>ctTasmota);
 
                 if (result.status != 200) {
                     console.log(`Could not set status: ${result.statusText} (${result.status})`);
@@ -171,7 +173,13 @@ class ColorTemperatureProperty extends WritableProperty<number> {
             async () => {
                 const response = await getStatus(host, password, 'CT');
                 const result = await response.json();
-                this.update(result.CT);
+                if(result)
+                {
+                  const ctTasmota: number = ((500-result?.CT) || 0)+153;
+                  const ctKelvin: number = 10.95*ctTasmota+1025;
+                  console.log(`CT Tasmota: ${ctTasmota}, Kelvin: ${ctKelvin}`);
+                  this.update(result.CT);
+                }
             });
     }
 }

--- a/src/tasmota-adapter.ts
+++ b/src/tasmota-adapter.ts
@@ -129,7 +129,11 @@ export class TasmotaAdapter extends Adapter {
       const colorResult = await colorResponse.json();
       const color: string = colorResult?.Color || "";
 
-      if (color.length >= 6) {
+      const ctResponse = await getStatus(host, password, 'CT');
+      const ctResult = await ctResponse.json();
+      const ct: number = ctResult?.CT || 0;
+
+      if (color.length >= 6 || ct != 0) {
         console.log('Found color device');
         const colorDevice = new Light(this, `${name}-color`, host, password);
         this.handleDeviceAdded(colorDevice);


### PR DESCRIPTION
Create the relevant properties required for #14 .

This includes the conversions between Kelvin and the units Tasmota uses for color temperature.

The webthings UI updates between a white and orange globe. However, for reasons that I am so far unable to determine the UI always assigns the value to 50 instead of any value I enter. As a result I can't assign a color temperature. I'd be very happy if there's something I missed, either way I think reading the color temperature is still helpful.